### PR TITLE
Libretro Settings problem by a Libretro core...

### DIFF
--- a/src/BizHawk.Client.EmuHawk/RetroAchievements/RCheevos.cs
+++ b/src/BizHawk.Client.EmuHawk/RetroAchievements/RCheevos.cs
@@ -34,6 +34,8 @@ namespace BizHawk.Client.EmuHawk
 			_cdreader = new(OpenTrackCallback, ReadSectorCallback, CloseTrackCallback, FirstTrackSectorCallback);
 			_lib.rc_hash_init_custom_filereader(ref _filereader);
 			_lib.rc_hash_init_custom_cdreader(ref _cdreader);
+
+			_http.DefaultRequestHeaders.UserAgent.ParseAdd($"BizHawk/{VersionInfo.GetEmuVersion()}");
 		}
 
 		private IntPtr _runtime;


### PR DESCRIPTION
[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

(describe changeset here)

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [ ] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2022-07-15) and am compliant

Good... My request is to solve the problem of the BizHawk emulator, with Libretro cores, that in their Libretro Settings, his window is all white, so that includes all the settings of it...
See the following image of this: https://media.discordapp.net/attachments/280813077853765632/1158881370223951943/Libretro_Settings.png?ex=652eff61&is=651c8a61&hm=9cce90f146a264cd6ae0e492a1772d898c7d3f7d2e51c2650ac19519464b66bb&=&width=1072&height=603
Thank You...